### PR TITLE
Add GitHub button to each page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,3 +6,7 @@ execute:
   execute_notebooks: 'off'
 parse:
   myst_extended_syntax: true
+# Information about where the book exists on the web
+repository:
+  url: https://github.com/wjbmattingly/holocaust_ner_lessons  # Online location of your book
+  branch: main  # Which branch of the repository should be used when creating links (optional)

--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,8 @@ parse:
 repository:
   url: https://github.com/wjbmattingly/holocaust_ner_lessons  # Online location of your book
   branch: main  # Which branch of the repository should be used when creating links (optional)
+html:
+  use_edit_page_button: true
+  use_issues_button: true
+  use_repository_button: true
+  


### PR DESCRIPTION
I just saw your post to CODE4LIB that mentioned possible typos, and soliciting feedback. 

It made me realize that your page didn't have GitHub buttons at the top like the JupyterHub documentation does (https://jupyterbook.org/customize/config.html#add-source-repository-buttons). Check out the rendered version at https://miketrizna.github.io/holocaust_ner_lessons/.